### PR TITLE
feat: Bump Ruby from 3.0.0 to 3.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.0.0"
+ruby "3.1.0"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.2"


### PR DESCRIPTION
### Description
Bump Ruby from 3.0.0 to 3.1.0
### Tickets related (optional)

### Screenshots (optional)
